### PR TITLE
Remove Typo which breaks update all

### DIFF
--- a/library/ibmim.py
+++ b/library/ibmim.py
@@ -346,7 +346,7 @@ class InstallationManager():
 
 		# Update everything
 		if self.module.params['state'] == 'latest':
-				self.updateAll(self.module_params)
+				self.updateAll(self.module.params)
 
 # import module snippets
 if __name__ == '__main__':


### PR DESCRIPTION
Update of all pages generated following error:
`File \"/tmp/ansible_ibmim_payload_nYbq6o/ansible_ibmim_payload.zip/ansible/modules/ibmim.py\", line 349, in main\r\nAttributeError: InstallationManager instance has no attribute 'module_params'\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}`
There was a typo in the call.