### PR TITLE
Fixed wrong index for create profile cli call

### DIFF
--- a/library/profile_dmgr.py
+++ b/library/profile_dmgr.py
@@ -143,7 +143,7 @@ def main():
                 ["{0}/bin/manageprofiles.sh -create "
                 "-profileName {1} "
                 "-profilePath {0}/profiles/{1} "
-                "-templatePath {0}/profileTemplates/{8} "
+                "-templatePath {0}/profileTemplates/{7} "
                 "-cellName {2} "
                 "-hostName {3} "
                 "-nodeName {4} "


### PR DESCRIPTION
There is no element at index 8, so the string format failed with _IndexError: tuple index out of range_. Since the template name is at index 7, I guess this a typo